### PR TITLE
'raise' syntax now compatible with python2

### DIFF
--- a/ring/func_base.py
+++ b/ring/func_base.py
@@ -1,5 +1,6 @@
 import functools
 from ring.key import CallableWrapper, CallableKey
+from six import raise_from
 
 
 def bypass(x):
@@ -196,7 +197,7 @@ class BaseInterface(object):
         try:
             action = kwargs.pop('action')
         except KeyError as exc:
-            raise TypeError("run() missing 1 required keyword argument: 'action'") from exc
+            raise_from(TypeError("run() missing 1 required keyword argument: 'action'"), exc)
 
         action_name = '_' + action
         if hasattr(self, action_name):

--- a/ring/func_base.py
+++ b/ring/func_base.py
@@ -1,6 +1,6 @@
 import functools
-from ring.key import CallableWrapper, CallableKey
 from six import raise_from
+from ring.key import CallableWrapper, CallableKey
 
 
 def bypass(x):

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     install_requires=[
         'prettyexc>=0.6.0',
         'callable>=0.1.1',
+        'six>=1.7',
     ],
     tests_require=tests_require + ['tox', 'tox-pyenv'],
     extras_require={


### PR DESCRIPTION
```from six import raise_from``` 는 어디에 적을까 고민하다가 가장 밑에 적었는데 [Style Guide](https://www.python.org/dev/peps/pep-0008/#imports) 를 찾아봤습니다.
```
Imports should be grouped in the following order:

1. standard library imports
2. related third party imports
3. local application/library specific imports
```
**functools**는 standard library, **ring**과 **six**는 모두 related third party 이니 이렇게 적는게 맞나요?