### PR TITLE
change service into services in For macOS in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,8 +139,8 @@ For macOS:
 .. code:: sh
 
     $ brew install libmemcached memcached redis
-    $ brew service start memcached
-    $ brew service start redis
+    $ brew services start memcached
+    $ brew services start redis
 
 
 For debian/ubuntu:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22931457/33112382-4b4f6e20-cf96-11e7-943f-33a38222c646.png)
"brew service" is not working in macOS

So i changes service into services
then, it's working!
![image](https://user-images.githubusercontent.com/22931457/33112425-7c99999c-cf96-11e7-8842-c54fa768ec3a.png)
