### PR TITLE
GC support

### DIFF
--- a/ring/func/asyncio.py
+++ b/ring/func/asyncio.py
@@ -452,7 +452,7 @@ class AioredisHashStorage(AioredisStorage):
 def dict(
         obj, key_prefix=None, expire=None, coder=None,
         user_interface=CacheUserInterface, storage_class=None,
-        **kwargs):
+        maxsize=128, **kwargs):
     """:class:`dict` interface for :mod:`asyncio`.
 
     :see: :func:`ring.func.sync.dict` for common description.
@@ -463,6 +463,7 @@ def dict(
             storage_class = fsync.PersistentDictStorage
         else:
             storage_class = fsync.ExpirableDictStorage
+        storage_class.maxsize = maxsize
 
     return fbase.factory(
         obj, key_prefix=key_prefix, on_manufactured=None,

--- a/ring/func/sync.py
+++ b/ring/func/sync.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, List
 import time
 import re
 import hashlib
+import threading, random, time
 
 from . import base as fbase, lru_cache as lru_mod
 
@@ -205,11 +206,82 @@ class LruStorage(fbase.CommonMixinStorage, fbase.StorageMixin):
         except KeyError:
             pass
 
+class Gc(object):
+
+    def __init__(self, backend, target_size, expire_f=None):
+        assert round(target_size) > 0, 'target_size has to be at least 1'
+        assert expire_f is None or callable(expire_f), 'expire_f has to be function or None'
+        assert isinstance(backend, type({})), 'backend has to be dict-like'
+        self._backend = backend
+        self._target_size = round(target_size)
+        self._expire_f = expire_f
+        self._mutex = threading.Lock()
+
+    def run(self):
+        class WorkThread(threading.Thread):
+            DEBUG = False
+
+            def __init__(self, outer_instance):
+                threading.Thread.__init__(self)
+                self._backend = outer_instance._backend
+                self._target_size = outer_instance._target_size
+                self._expire_f = outer_instance._expire_f
+                self._mutex = outer_instance._mutex
+
+            def strategy_with_expire(self):
+                MAX_EXPIRE_RETRY_COUNT = 4
+                now = time.time()
+                retry_count = 0
+                keys = list(self._backend.keys())
+                while (len(self._backend) > self._target_size) and (retry_count < MAX_EXPIRE_RETRY_COUNT):
+                    k = keys.pop(random.randrange(len(keys)))
+                    val = self._backend.get(k, None)
+                    if val is None:
+                        continue
+                    expire = self._expire_f(val)
+                    if expire < now:
+                        self._backend.pop(k, None)
+                        self.print_d('{} removed from strategy_with_expire => size {}'.format(k, len(self._backend)))
+                    else:
+                        retry_count += 1
+                    if len(keys) == 0:
+                        keys = list(self._backend.keys())
+
+            def strategy_with_force(self):
+                keys = list(self._backend.keys())
+                while (len(self._backend) > self._target_size) and len(keys) > 0:
+                    k = keys.pop(random.randrange(len(keys)))
+                    self._backend.pop(k, None)
+                    self.print_d('{} removed from strategy_with_force => size {}'.format(k, len(self._backend)))
+                    if len(keys) == 0:
+                        keys = list(self._backend.keys())
+
+            def run(self):
+                try:
+                    self.print_d('gc started in size:{}'.format(len(self._backend)))
+                    if self._expire_f is not None:
+                        self.strategy_with_expire()
+                    self.strategy_with_force()
+                    self.print_d('gc ended in size:{}'.format(len(self._backend)))
+                finally:
+                    self._mutex.release()
+
+
+            def print_d(self, str_):
+                if self.DEBUG:
+                    print(str_)
+
+        self._mutex.acquire()
+        if (len(self._backend) > self._target_size):
+            WorkThread(self).start()
+        else:
+            self._mutex.release()
 
 class ExpirableDictStorage(fbase.CommonMixinStorage, fbase.StorageMixin):
-
+    maxsize = 128
     in_memory_storage = True
     now = time.time
+    _gc = None
 
     def get_value(self, key):
         _now = self.now()
@@ -228,6 +300,11 @@ class ExpirableDictStorage(fbase.CommonMixinStorage, fbase.StorageMixin):
         else:
             expired_time = _now + expire
         self.backend[key] = expired_time, value
+
+        if self.maxsize < len(self.backend):
+            if self._gc == None:
+                self._gc = Gc(self.backend, self.maxsize * 0.75, lambda x: x[0])
+            self._gc.run()
 
     def delete_value(self, key):
         try:
@@ -252,8 +329,9 @@ class ExpirableDictStorage(fbase.CommonMixinStorage, fbase.StorageMixin):
 
 
 class PersistentDictStorage(fbase.CommonMixinStorage, fbase.StorageMixin):
-
     in_memory_storage = True
+    maxsize = 128
+    _gc = None
 
     def get_value(self, key):
         try:
@@ -264,6 +342,10 @@ class PersistentDictStorage(fbase.CommonMixinStorage, fbase.StorageMixin):
 
     def set_value(self, key, value, expire):
         self.backend[key] = value
+        if self.maxsize < len(self.backend):
+            if self._gc == None:
+                self._gc = Gc(self.backend, self.maxsize * 0.75)
+            self._gc.run()
 
     def delete_value(self, key):
         try:
@@ -443,7 +525,7 @@ def lru(
 def dict(
         obj, key_prefix=None, expire=None, coder=None,
         user_interface=CacheUserInterface, storage_class=None,
-        **kwargs):
+        maxsize=128, **kwargs):
     """Basic Python :class:`dict` based cache.
 
     This backend is not designed for real products. Please carefully read the
@@ -467,6 +549,7 @@ def dict(
             storage_class = PersistentDictStorage
         else:
             storage_class = ExpirableDictStorage
+        storage_class.maxsize = maxsize
 
     return fbase.factory(
         obj, key_prefix=key_prefix, on_manufactured=None,

--- a/tests/test_dict_gc.py
+++ b/tests/test_dict_gc.py
@@ -1,0 +1,127 @@
+
+import ring
+
+
+def test_dict_gc_persistence_1():
+    import time
+    cache = {}
+
+    @ring.dict(cache, maxsize=1)
+    def f_persistent_1(i):
+        return i
+
+    for i in range(100):
+        f_persistent_1(i)
+        time.sleep(0.02)
+        assert len(cache) <= 1
+
+def test_dict_gc_persistence_default():
+    import time
+    cache = {}
+
+    @ring.dict(cache)
+    def f_persistent_default(i):
+        return i
+
+    for i in range(1000):
+        f_persistent_default(i)
+    time.sleep(0.1)
+    assert len(cache) <= 128
+
+def test_dict_gc_persistent_random_delete():
+    import time
+    cache = {}
+    MAX_SIZE = 10
+
+    @ring.dict(cache, maxsize=MAX_SIZE)
+    def f_persistent_random_delete(i):
+        return i
+
+    for i in range(1000):
+        f_persistent_random_delete(i)
+        if i % 17 == 0:
+            for pop_count in range(8):
+                try:
+                    cache.popitem()
+                except KeyError:
+                    pass
+    time.sleep(0.1)
+    assert len(cache) <= MAX_SIZE
+
+def test_dict_gc_expire_1():
+    import time
+    cache = {}
+    MAX_SIZE = 1
+
+    @ring.dict(cache, maxsize=MAX_SIZE, expire=1)
+    def f_expire_1(i):
+        return i
+
+    for i in range(MAX_SIZE * 100):
+        f_expire_1(i)
+        time.sleep(0.02)
+        assert len(cache) <= MAX_SIZE
+
+def test_dict_gc_expire_many():
+    import time
+    cache = {}
+    MAX_SIZE = 50000
+
+    @ring.dict(cache, maxsize=MAX_SIZE, expire=1)
+    def f_expire_1(i):
+        return i
+
+    for i in range(MAX_SIZE * 10):
+        f_expire_1(i)
+
+    time.sleep(0.1)
+    assert len(cache) <= MAX_SIZE
+
+def test_dict_gc_expire_some():
+    import time
+    cache = {}
+
+    @ring.dict(cache, maxsize=150, expire=1)
+    def f_expire_some_expire(i):
+        return i
+
+    for i in range(100):
+        f_expire_some_expire(i)
+    time.sleep(1)
+    for i in range(100, 200):
+        f_expire_some_expire(i)
+    assert len(cache) <= 150
+
+def test_dict_gc_expire_default():
+    import time
+    cache = {}
+
+    @ring.dict(cache, expire=1)
+    def f_expire_default(i):
+        return i
+
+    for i in range(1000):
+        f_expire_default(i)
+    time.sleep(0.1)
+    assert len(cache) <= 128
+
+def test_dict_gc_expire_random():
+    import time
+    cache = {}
+
+    @ring.dict(cache, maxsize=10, expire=1)
+    def f_expire_random(i):
+        return i
+
+    for i in range(1000):
+        f_expire_random(i)
+    time.sleep(1)
+    for i in range(1000, 2000):
+        f_expire_random(i)
+        if i % 17 == 0:
+            for pop_count in range(8):
+                try:
+                    cache.popitem()
+                except KeyError:
+                    pass
+    assert len(cache) <= 10


### PR DESCRIPTION
1. Added `Gc` class to sync.py
2. Mounted to `ExpirableDictStorage` and `PersistentDictStorage`
3. `dict` interface changed

Solves  #115 issue.
- Although the python collection blocks when GC-ing, I decided to go multithreading. Thread creation will be mutexed so only one thread will be created. I carefully tested this and will work fine.
- `DEBUG` variable in Gc class is for debug log purpose. If you know the better way, please, let me know.
- I saved the updating documentation work to more suitable person 😄 
- Quick question, is this strategy commonly used in CS? I am not a GC expert and only know a couple of strategies such as `mark & sweep` etc.
