### PR TITLE
Add aioredis tests for both client/pool

### DIFF
--- a/tests/_test_func_asyncio.py
+++ b/tests/_test_func_asyncio.py
@@ -51,6 +51,19 @@ def aioredis_pool():
         pytest.skip()
 
 
+@pytest.fixture()
+def aioredis_connection():
+    if sys.version_info <= (3, 5):
+        pytest.skip()
+
+    import aioredis
+
+    connection_coroutine = aioredis.create_redis(
+        ('localhost', 6379)
+    )
+
+    return connection_coroutine, ring.aioredis
+
 @pytest.fixture(params=[
     lazy_fixture('storage_dict'),
     lazy_fixture('aiomcache_client'),


### PR DESCRIPTION
Now ring's tests only test with aioredis's connection pool, so modify the test to use both aioredis connection and connection pool.

- Added aioredis connection fixture with the same interface as aioredis pool fixture
- Modified tests to use both pool and connection

- Fix #110