### PR TITLE
Improve compatibility with functools.lru_cache

### DIFF
--- a/ring/func/lru_cache.py
+++ b/ring/func/lru_cache.py
@@ -78,6 +78,8 @@ class LruCache(object):
 
         def set(key, result, expire=None):
             expired_time = expiration_time(expire)
+            if maxsize == 0:
+                return
             with lock:
                 link = cache_get(key)
                 if link is not None:
@@ -114,7 +116,10 @@ class LruCache(object):
                     last[NEXT] = root[PREV] = cache[key] = link
                     # Use the cache_len bound method instead of the len() function
                     # which could potentially be wrapped in an lru_cache itself.
-                    stat[FULL] = (cache_len() >= maxsize)
+                    if maxsize is not None and not isinstance(maxsize, int):
+                        raise TypeError('Expected maxsize to be an integer or None')
+                    if maxsize is not None:
+                        stat[FULL] = (cache_len() >= maxsize)
 
         def cache_info():
             """Report cache statistics"""

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,4 +1,7 @@
 from functools import update_wrapper
+
+import pytest
+
 from ring.func.lru_cache import LruCache, SENTINEL
 
 try:
@@ -153,3 +156,7 @@ def test_maxsize_compatibility_check():
     lru.set('a', 10)
 
     assert lru.get('a') == SENTINEL
+
+    lru = LruCache('test')
+    with pytest.raises(TypeError):
+        lru.set('a', 10)


### PR DESCRIPTION
 - Added tests case for same `cache_info()` with `functools.lru_cache` implementation
 - Fixes #136 