### PR TITLE
Fix install_require to fit environment markers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ norecursedirs=.git py ci
 [flake8]
 ignore=E501,E701
 [metadata]
-version-from-file: ring/__init__.py
+version_from_file: ring/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ install_requires = [
     'six>=1.11.0',
     'wirerope==0.4.3',
     'attrs>=19.3.0',
+    'inspect2>=0.1.0;python_version<"3.0.0"',
+    'functools32>=3.2.3-2>=0.1.0;python_version<"3.0"',
 ]
 tests_require = [
     'pytest>=3.10.1', 'pytest-cov', 'pytest-lazy-fixture==0.6.2',
@@ -62,12 +64,6 @@ else:
         'python3-memcached',
     ])
 
-# backports - py2
-if sys.version_info[0] == 2:
-    install_requires.extend([
-        'inspect2>=0.1.0',
-        'functools32>=3.2.3-2',
-    ])
 
 dev_require = tests_require + docs_require
 


### PR DESCRIPTION
[PEP-0508](https://www.python.org/dev/peps/pep-0508/#environment-markers)

One of python package manager [Poetry](https://python-poetry.org/) cannot see `sys.version_info` 
