### PR TITLE
ring_executor -> _executor

### DIFF
--- a/ring/func/asyncio.py
+++ b/ring/func/asyncio.py
@@ -76,10 +76,10 @@ def create_asyncio_factory_proxy(factory_table, *, support_asyncio):
 
 def async_wrap(func):
     @wraps(func)
-    async def run(*args, ring_executor=None, **kwargs):
+    async def run(*args, _executor=None, **kwargs):
         loop = asyncio.get_event_loop()
         pfunc = partial(func, *args, **kwargs)
-        return await loop.run_in_executor(ring_executor, pfunc)
+        return await loop.run_in_executor(_executor, pfunc)
 
     return run
 


### PR DESCRIPTION
@yangroro usually `_` prefixed parameter is not used for regular functions. So I thought this is enough for here.