### PR TITLE
Fix "RuntimeError: There is no current event loop in thread 'MainThread'."

### DIFF
--- a/ring/__init__.py
+++ b/ring/__init__.py
@@ -10,7 +10,7 @@ from ring.func import (
 try:
     import asyncio
     from ring.func.asyncio import aiomcache, aioredis, aioredis_hash
-except (ImportError, RunTimeError):
+except (ImportError, RuntimeError):
     pass
 else:
     del asyncio

--- a/ring/__init__.py
+++ b/ring/__init__.py
@@ -10,7 +10,7 @@ from ring.func import (
 try:
     import asyncio
     from ring.func.asyncio import aiomcache, aioredis, aioredis_hash
-except ImportError:
+except (ImportError, RunTimeError):
     pass
 else:
     del asyncio

--- a/ring/func/__init__.py
+++ b/ring/func/__init__.py
@@ -8,7 +8,7 @@ from ring.func import sync
 
 try:
     import asyncio as _has_asyncio
-except ImportError:
+except (ImportError, RuntimeError):
     _has_asyncio = False
 else:
     from ring.func import asyncio

--- a/ring/func/__init__.py
+++ b/ring/func/__init__.py
@@ -11,7 +11,10 @@ try:
 except (ImportError, RuntimeError):
     _has_asyncio = False
 else:
-    from ring.func import asyncio
+    try:
+        from ring.func import asyncio
+    except RuntimeError:
+        _has_asyncio = False
 
 
 __all__ = (


### PR DESCRIPTION
Even if ring is not used asyncronously, there is the possibility that another library such as `eventlet` crashes with ring's current way of checking whether it's possible to use `asyncio`. In some cases, there's a chance that an error of the form `RuntimeError: There is no current event loop in thread 'MainThread'.`

To control for this, this PR controls that no `RuntimeError` is raised during the import of `asyncio`, and resorts to `_has_asyncio = False` if that happens.

