### PR TITLE
fix: support abc.ABCMeta in coerce_function

### DIFF
--- a/ring/func/base.py
+++ b/ring/func/base.py
@@ -214,7 +214,7 @@ def coerce_function(t):
     if issubclass(t, (list, tuple)):
         return _coerce_list_and_tuple
 
-    if t is type:
+    if t is type or t is abc.ABCMeta:
         return _coerce_type
 
     if issubclass(t, dict):

--- a/tests/test_coerce.py
+++ b/tests/test_coerce.py
@@ -1,3 +1,4 @@
+import abc
 import sys
 
 import pytest
@@ -37,6 +38,10 @@ class HashUser(object):
         return str(self.user_id)
 
 
+class ABCUser(abc.ABC):
+    pass
+
+
 ring_key_instance = User(42)
 ring_hash_instance = HashUser(42)
 test_parameters = [
@@ -49,6 +54,8 @@ test_parameters = [
     ({1, 2, 3, 4}, "{1,2,3,4}"),
     ({"1", "2", "3", "4"}, "{'1','2','3','4'}"),
     (("1", "2", "3", "4"), "('1','2','3','4')"),
+    (User, "User"),
+    (ABCUser, "ABCUser"),
 ]
 if numpy is not None:
     test_parameters.extend(


### PR DESCRIPTION
fix #202 